### PR TITLE
Mac stability3 - Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules/*
 *.log
 *.Log
 *.LOG
+*/documentation/*
+documentation/*
+*.html
+*.HTML

--- a/build/buildRelease/package.json
+++ b/build/buildRelease/package.json
@@ -23,7 +23,7 @@
   "author": "Seth Hollingsead",
   "license": "MIT",
   "dependencies": {
-    "@haystacks/async": "0.1.12",
+    "@haystacks/async": "0.2.0",
     "@haystacks/constants": "0.2.0"
   },
   "bugs": {

--- a/test/testHarness/package.json
+++ b/test/testHarness/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.0.0",
-    "@haystacks/async": "0.1.12",
+    "@haystacks/async": "0.2.0",
     "@haystacks/constants": "0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update dependencies and update the gitIgnore to block the documentation from getting refreshed for minor releases after this major release.